### PR TITLE
Integration with JPlugin.

### DIFF
--- a/code/site/api.php
+++ b/code/site/api.php
@@ -25,6 +25,7 @@ JLoader::register('APIResource', $library_path.'/resource.php');
 JLoader::register('APIAuthentication', $library_path.'/authentication.php');
 JLoader::register('APIAuthenticationKey', $library_path.'/authentication/key.php');
 JLoader::register('APIAuthenticationLogin', $library_path.'/authentication/login.php');
+JLoader::register('APIHelper', $library_path.'/helper.php');
 
 $app = JFactory::getApplication();
 

--- a/code/site/libraries/plugin.php
+++ b/code/site/libraries/plugin.php
@@ -12,10 +12,9 @@ defined('_JEXEC') or die( 'Restricted access' );
 
 jimport('joomla.plugin.plugin');
 
-class ApiPlugin extends JObject {
+class ApiPlugin extends JPlugin {
 
 	protected $user				= null;
-	protected $params			= null;
 	protected $format			= null;
 	protected $response			= null;
 	protected $request			= null;
@@ -40,6 +39,15 @@ class ApiPlugin extends JObject {
 		if (isset(self::$instances[$name])) :
 			return self::$instances[$name];
 		endif;
+
+                if (version_compare(JVERSION, "3.0", "l"))
+                {
+                    $dispatcher = JDispatcher::getInstance();
+                }
+                else
+                {
+                    $dispatcher = JEventDispatcher::getInstance();
+                }
 
 		$plugin	= JPluginHelper::getPlugin('api', $name);
 
@@ -69,14 +77,9 @@ class ApiPlugin extends JObject {
 			ApiError::raiseError(400, JText::_('COM_API_PLUGIN_CLASS_NOT_FOUND'));
 		endif;
 
-		$handler	=  new $class();
+                $cparams        = JComponentHelper::getParams('com_api');
 
-		$cparams	= JComponentHelper::getParams('com_api');
-		//$params		= new JParameter($plugin->params, $param_path);
-		$params		= new JRegistry($plugin->params, $param_path);
-		$cparams->merge($params);
-
-		$handler->set('params', $cparams);
+		$handler	=  new $class($dispatcher, array('params'=>$cparams));
 
 		/*$handler->set('component', JRequest::getCmd('app'));
 		$handler->set('resource', JRequest::getCmd('resource'));
@@ -126,9 +129,9 @@ class ApiPlugin extends JObject {
 		return self::$instances[$name];
 	}
 
-	public function __construct()
+	public function __construct(&$subject, $config = array())
 	{
-
+            parent::__construct($subject, $config);
 	}
 
 	//public function __call($name, $arguments) {


### PR DESCRIPTION
Extend JPlugin rather than JObject for API plugin class. My recommendation would also be to replace fetchResource with an event method, E.g. onAPIFetchResource and to remove getInstance to more closely match Joomla's plugin conventions.

Please let me know if you would like me to make these changes.
