### PR TITLE
Issue #80 Fix: Tokens should not be accepted via request variables

### DIFF
--- a/code/site/libraries/authentication.php
+++ b/code/site/libraries/authentication.php
@@ -182,13 +182,14 @@ abstract class ApiAuthentication extends JObject
 	private static function getAuthMethod()
 	{
 		$app = JFactory::getApplication();
-		$key = $app->input->get('key');
+
+		// $key = $app->input->get('key');
 
 		if (isset($_SERVER['HTTP_X_AUTH']) && $_SERVER['HTTP_X_AUTH'])
 		{
 			$authMethod = $_SERVER['HTTP_X_AUTH'];
 		}
-		elseif ($key || self::getBearerToken())
+		elseif (self::getBearerToken())
 		{
 			$authMethod = 'key';
 		}

--- a/code/site/libraries/authentication/key.php
+++ b/code/site/libraries/authentication/key.php
@@ -30,10 +30,14 @@ class ApiAuthenticationKey extends ApiAuthentication
 	public function authenticate()
 	{
 		$app          = JFactory::getApplication();
-		$query_token  = $app->input->get('key', '', 'STRING');
+
+		// $query_token  = $app->input->get('key', '', 'STRING');
+
 		$header_token = $this->getBearerToken();
-		$key          = $header_token ? $header_token : $query_token;
-		$token        = $this->loadTokenByHash($key);
+
+		// $key = $header_token ? $header_token : $query_token;
+
+		$token  = $this->loadTokenByHash($header_token);
 
 		if (isset($token->state) && $token->state == 1)
 		{

--- a/code/site/libraries/plugin.php
+++ b/code/site/libraries/plugin.php
@@ -349,7 +349,10 @@ class ApiPlugin extends JPlugin
 			return true;
 		}
 
-		$hash = $app->input->get('key', '', 'STRING');
+		// $hash = $app->input->get('key', '', 'STRING');
+
+		$hash = APIAuthentication::getBearerToken();
+
 		$ip_address = $app->input->server->get('REMOTE_ADDR', '', 'STRING');
 
 		$time = $this->params->get('request_limit_time', 'hour');
@@ -442,7 +445,10 @@ class ApiPlugin extends JPlugin
 
 		$table = JTable::getInstance('Log', 'ApiTable');
 		$date = JFactory::getDate();
-		$table->hash = $app->input->get('key', '', 'STRING');
+
+		// $table->hash = $app->input->get('key', '', 'STRING');
+
+		$table->hash = APIAuthentication::getBearerToken();
 		$table->ip_address = $app->input->server->get('REMOTE_ADDR', '', 'STRING');
 		$table->time = $date->toSql();
 		$table->request = $req_url;
@@ -465,7 +471,10 @@ class ApiPlugin extends JPlugin
 		$app = JFactory::getApplication();
 		$table = JTable::getInstance('Key', 'ApiTable');
 
-		$hash = $app->input->get('key', '', 'STRING');
+		// $hash = $app->input->get('key', '', 'STRING');
+
+		$hash = APIAuthentication::getBearerToken();
+
 		$table->setLastUsed($hash);
 	}
 


### PR DESCRIPTION
1. Wherever key is needed then that key is retried from the request header instead of the input object.
2. Please check implementation is correct.
3. Once confirmed will remove the commented code.