### PR TITLE
Fix the checkRequestLimit query to use the correct timestamp

### DIFF
--- a/code/site/libraries/plugin.php
+++ b/code/site/libraries/plugin.php
@@ -354,23 +354,24 @@ class ApiPlugin extends JPlugin
 
 		$time = $this->params->get('request_limit_time', 'hour');
 
+		$now = JFactory::getDate();
 		switch ($time)
 		{
 			case 'day':
-				$offset = 60 * 60 * 24;
+				$now->modify('-1 day');
 				break;
 
 			case 'minute':
-				$offset = 60;
+				$now->modify('-1 minute');
 				break;
 
 			case 'hour':
 			default:
-				$offset = 60 * 60;
+				$now->modify('-1 hour');
 				break;
 		}
 
-		$query_time = time() - $offset;
+		$query_time = $now->toSql();
 
 		$db = JFactory::getDBO();
 		$query = $db->getQuery(true);


### PR DESCRIPTION
When checking if the request limit is exceeded, the constructed query uses a timestamp in Unix timestamp format while the log table stores the timestamp as SQL datetime. Therefore, the incorrect number of log-records are returned and the user can incorrectly get the '403 Rate Limit Exceeded' message.

This PR fixes this by using the same construction for the timestamp during the retrieval of log entries as during the saving of log entries